### PR TITLE
Mac OSX support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+build/
+dist/
+loopertrx.egg-info/
+

--- a/scripts/osx_check.sh
+++ b/scripts/osx_check.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+signed_kext_status=$(csrutil status)
+if [[ $signed_kext_status = *"enabled"* ]]; then
+  echo "**MAC OSX ERROR** Unsigned kernex extentions not allowed! To allow them restart in recovery OS by restarting and holding Cmd+R, open a shell and run 'csrutil disable'"
+  exit 1
+fi

--- a/scripts/osx_post_install.sh
+++ b/scripts/osx_post_install.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+KEXT_PATH="/System/Library/Extensions/AmmoonLooperUsb.kext/Contents/"
+
+${SCRIPT_DIR}/osx_check.sh
+
+mkdir -p "${KEXT_PATH}"
+cp "${SCRIPT_DIR}"/resources/Info.plist "${KEXT_PATH}"
+
+kextload /System/Library/Extensions/AmmoonLooperUsb.kext
+touch /System/Library/Extensions
+

--- a/scripts/resources/Info.plist
+++ b/scripts/resources/Info.plist
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>English</string>
+    <key>CFBundleGetInfoString</key>
+    <string>Ammoon AP-09 Nano Looper</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.ammoon.looper</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>Ammoon AP-09 Nano Looper</string>
+    <key>CFBundlePackageType</key>
+    <string>KEXT</string>
+    <key>CFBundleSignature</key>
+    <string>not-signed</string>
+    <key>CFBundleVersion</key>
+    <string>1.0.0</string>
+    <key>IOKitPersonalities</key>
+    <dict>
+        <key>Device Driver</key>
+        <dict>
+            <key>CFBundleIdentifier</key>
+            <string>com.apple.iokit.IOUSBMassStorageDriver</string>
+            <key>IOClass</key>
+            <string>IOService</string>
+            <key>IOProviderClass</key>
+            <string>IOUSBInterface</string>
+            <key>idProduct</key>
+            <integer>22314</integer>
+            <key>idVendor</key>
+            <integer>1155</integer>
+            <key>bConfigurationValue</key>
+            <integer>1</integer>
+            <key>bInterfaceNumber</key>
+            <integer>0</integer>
+        </dict>
+    </dict>
+    <key>OSBundleRequired</key>
+    <string>Local-Root</string>
+</dict>
+</plist>

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+import os, subprocess
 from setuptools import setup, find_packages
 
 setup(
@@ -11,3 +12,12 @@ setup(
     author_email="reiner@reiner-h.de",
     license="GPLv2+",
 )
+
+if(os.uname().sysname == "Darwin"):
+    project_dir = os.path.dirname(os.path.realpath(__file__))
+    mac_setup_script = os.path.join(project_dir, "scripts", "osx_check.sh")
+    subprocess.check_call(mac_setup_script)
+    print("################################################")
+    print("OSX Installation Notice")
+    print("################################################")
+    print("In order to fully complete the installation, run 'sudo scripts/osx_post_install.sh'")


### PR DESCRIPTION
Hi,

I have an ammoon ap-09 nano looper and was quite excited to find your repository! However it did not work out of the box. Mac OS was binding some default system driver to the device and `pyusb` does not seem to implement `detach_kernel_driver` for mac. 

Therefore I created a minimalistic OSX kernel extension placeholder (metadata only, no code) that will fool Mac OSX that it is a driver for the looper and will prevent the default driver from capturing the device. With this in place the python script works! 

This PR adds a shell script that Mac users can run after they `python setup.py install`. I have also hooked into the `setup.py` itself notifying Mac users that they need to take an extra step.

Disclaimer: While this made receiving and transmitting work on mac I am still facing a problem (at least on my macbook). When I receive a loop.wav and play it there is A LOT of noise to an extent which makes it unusable. Weirdly, when I upload the same file back up to the device and pay it on my amp it has fine quality again. You mentioned in the README that the original software does some extra processing after downloading the bits. How did you find that out? Do you have some clue of what they are doing and if it can be easily incorporated in this tool? Any information will be highly appreciated.

And thanks for this tool once again :)

Cheers,
Georgi